### PR TITLE
Changing background back to grey when using kramdown

### DIFF
--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -12,7 +12,6 @@ title: Starting With Data
 * Load a Python/Pandas library.
 * Read tabular data from a file into Python using Pandas using `read_csv`.
 * Learn about the Pandas DataFrame object.
-* Learn about data slicing and indexing.
 * Perform mathematical operations on numeric data.
 * Create simple plots of data.
 
@@ -21,7 +20,7 @@ title: Starting With Data
 For this lesson, we will be using the Portal Teaching data, a subset of the data from Ernst et al [Long-term monitoring and experimental manipulation of a Chihuahuan Desert ecosystem near Portal, Arizona, USA](http://www.esapubs.org/archive/ecol/E090/118/default.htm)
 
 We are studying the species and weight of animals caught in plots in our study
-area. The dataset is stored as a `csv` file: each row holds information for a
+area. The dataset is stored as a `.csv` file: each row holds information for a
 single animal, and the columns represent:
 
 | Column           | Description                        |
@@ -39,9 +38,9 @@ single animal, and the columns represent:
 
 ### Download lesson data
 
-We will be using files from the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459)
+We will be using files from the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459).
 
-This section will use surveys.csv that can be downloaded here: [https://ndownloader.figshare.com/files/2292172](https://ndownloader.figshare.com/files/2292172)
+This section will use the `surveys.csv` file that can be downloaded here: [https://ndownloader.figshare.com/files/2292172](https://ndownloader.figshare.com/files/2292172)
 
 ---
 
@@ -82,7 +81,7 @@ time we call a Pandas function.
 For this lesson we will be using the Portal Teaching data.
 
 We are studying the species and weight of animals caught in plots in a study
-area. The data sets are stored in .csv (comma separated values) format. Within
+area. The data sets are stored in `.csv` (comma separated values) format. Within
 the `.csv` files, each row holds information for a single animal, and the
 columns represent: record_id, month, day, year, plot, species, sex, wgt.
 
@@ -103,9 +102,9 @@ record_id,month,day,year,plot_id,species_id,sex,hindfoot_length,weight
 
 ### We want to:
 
-1. Load that data into memory in Python.
+1. Load that data into memory using Python.
 2. Calculate the average weight of all individuals sampled, by species.
-3. Plot the average weights by species and perhaps by plot too.
+3. Plot the average weights by species and perhaps by plot_id too.
 
 We can automate the process above using Python. It's efficient to spend time
 building the code to perform these tasks because once it's built, we can use it
@@ -128,7 +127,8 @@ in columns. It is similar to a spreadsheet or an SQL table or the `data.frame` i
 R.
 
 First, let's make sure the Python Pandas library is loaded. We will import
-Pandas using the nickname `pd`.
+Pandas using the nickname `pd`.  This is a common convention on the internet,
+so if you look up Pandas usage, you will often see it this way.
 
 ```python
 import pandas as pd
@@ -149,7 +149,7 @@ os.chdir("YOURPathHere")
 
 ```python
 # note that pd.read_csv is used because we imported pandas as pd
-pd.read_csv("https://ndownloader.figshare.com/files/2292172")
+pd.read_csv("surveys.csv")
 ```
 
 The above command yields the **output** below:
@@ -181,7 +181,7 @@ variable name by assigning a value to it using `=`.
 Let's call the imported survey data `surveys_df`:
 
 ```python
-surveys_df = pd.read_csv("https://ndownloader.figshare.com/files/2292172")
+surveys_df = pd.read_csv("surveys.csv")
 ```
 
 Notice when you assign the imported DataFrame to a variable, Python does not

--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -12,19 +12,15 @@ title: Starting With Data
 * Load a Python/Pandas library.
 * Read tabular data from a file into Python using Pandas using `read_csv`.
 * Learn about the Pandas DataFrame object.
-* Learn about data slicing and indexing.
 * Perform mathematical operations on numeric data.
 * Create simple plots of data.
 
 ## Presentation of the survey data
 
-For this lesson, we will be using the Portal Teaching data, a subset of the
-data from Ernst et al [Long-term monitoring and experimental manipulation of a
-Chihuahuan Desert ecosystem near Portal, Arizona,
-USA](http://www.esapubs.org/archive/ecol/E090/118/default.htm)
+For this lesson, we will be using the Portal Teaching data, a subset of the data from Ernst et al [Long-term monitoring and experimental manipulation of a Chihuahuan Desert ecosystem near Portal, Arizona, USA](http://www.esapubs.org/archive/ecol/E090/118/default.htm)
 
 We are studying the species and weight of animals caught in plots in our study
-area. The dataset is stored as a `csv` file: each row holds information for a
+area. The dataset is stored as a `.csv` file: each row holds information for a
 single animal, and the columns represent:
 
 | Column           | Description                        |
@@ -42,9 +38,9 @@ single animal, and the columns represent:
 
 ### Download lesson data
 
-We will be using files from the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459)
+We will be using files from the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459).
 
-This section will use surveys.csv that can be downloaded here: [https://ndownloader.figshare.com/files/2292172](https://ndownloader.figshare.com/files/2292172)
+This section will use the `surveys.csv` file that can be downloaded here: [https://ndownloader.figshare.com/files/2292172](https://ndownloader.figshare.com/files/2292172)
 
 ---
 
@@ -85,7 +81,7 @@ time we call a Pandas function.
 For this lesson we will be using the Portal Teaching data.
 
 We are studying the species and weight of animals caught in plots in a study
-area. The data sets are stored in .csv (comma separated values) format. Within
+area. The data sets are stored in `.csv` (comma separated values) format. Within
 the `.csv` files, each row holds information for a single animal, and the
 columns represent: record_id, month, day, year, plot, species, sex, wgt.
 
@@ -106,9 +102,9 @@ record_id,month,day,year,plot_id,species_id,sex,hindfoot_length,weight
 
 ### We want to:
 
-1. Load that data into memory in Python.
+1. Load that data into memory using Python.
 2. Calculate the average weight of all individuals sampled, by species.
-3. Plot the average weights by species and perhaps by plot too.
+3. Plot the average weights by species and perhaps by plot_id too.
 
 We can automate the process above using Python. It's efficient to spend time
 building the code to perform these tasks because once it's built, we can use it
@@ -131,7 +127,8 @@ in columns. It is similar to a spreadsheet or an SQL table or the `data.frame` i
 R.
 
 First, let's make sure the Python Pandas library is loaded. We will import
-Pandas using the nickname `pd`.
+Pandas using the nickname `pd`.  This is a common convention on the internet,
+so if you look up Pandas usage, you will often see it this way.
 
 ```python
 import pandas as pd
@@ -152,7 +149,7 @@ os.chdir("YOURPathHere")
 
 ```python
 # note that pd.read_csv is used because we imported pandas as pd
-pd.read_csv("https://ndownloader.figshare.com/files/2292172")
+pd.read_csv("surveys.csv")
 ```
 
 The above command yields the **output** below:
@@ -184,7 +181,7 @@ variable name by assigning a value to it using `=`.
 Let's call the imported survey data `surveys_df`:
 
 ```python
-surveys_df = pd.read_csv("https://ndownloader.figshare.com/files/2292172")
+surveys_df = pd.read_csv("surveys.csv")
 ```
 
 Notice when you assign the imported DataFrame to a variable, Python does not

--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -17,7 +17,10 @@ title: Starting With Data
 
 ## Presentation of the survey data
 
-For this lesson, we will be using the Portal Teaching data, a subset of the data from Ernst et al [Long-term monitoring and experimental manipulation of a Chihuahuan Desert ecosystem near Portal, Arizona, USA](http://www.esapubs.org/archive/ecol/E090/118/default.htm)
+For this lesson, we will be using the Portal Teaching data, a subset of the
+data from Ernst et al [Long-term monitoring and experimental manipulation of a
+Chihuahuan Desert ecosystem near Portal, Arizona,
+USA](http://www.esapubs.org/archive/ecol/E090/118/default.htm)
 
 We are studying the species and weight of animals caught in plots in our study
 area. The dataset is stored as a `.csv` file: each row holds information for a

--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -12,6 +12,7 @@ title: Starting With Data
 * Load a Python/Pandas library.
 * Read tabular data from a file into Python using Pandas using `read_csv`.
 * Learn about the Pandas DataFrame object.
+* Learn about data slicing and indexing.
 * Perform mathematical operations on numeric data.
 * Create simple plots of data.
 
@@ -23,7 +24,7 @@ Chihuahuan Desert ecosystem near Portal, Arizona,
 USA](http://www.esapubs.org/archive/ecol/E090/118/default.htm)
 
 We are studying the species and weight of animals caught in plots in our study
-area. The dataset is stored as a `.csv` file: each row holds information for a
+area. The dataset is stored as a `csv` file: each row holds information for a
 single animal, and the columns represent:
 
 | Column           | Description                        |
@@ -41,9 +42,9 @@ single animal, and the columns represent:
 
 ### Download lesson data
 
-We will be using files from the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459).
+We will be using files from the [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459)
 
-This section will use the `surveys.csv` file that can be downloaded here: [https://ndownloader.figshare.com/files/2292172](https://ndownloader.figshare.com/files/2292172)
+This section will use surveys.csv that can be downloaded here: [https://ndownloader.figshare.com/files/2292172](https://ndownloader.figshare.com/files/2292172)
 
 ---
 
@@ -84,7 +85,7 @@ time we call a Pandas function.
 For this lesson we will be using the Portal Teaching data.
 
 We are studying the species and weight of animals caught in plots in a study
-area. The data sets are stored in `.csv` (comma separated values) format. Within
+area. The data sets are stored in .csv (comma separated values) format. Within
 the `.csv` files, each row holds information for a single animal, and the
 columns represent: record_id, month, day, year, plot, species, sex, wgt.
 
@@ -105,9 +106,9 @@ record_id,month,day,year,plot_id,species_id,sex,hindfoot_length,weight
 
 ### We want to:
 
-1. Load that data into memory using Python.
+1. Load that data into memory in Python.
 2. Calculate the average weight of all individuals sampled, by species.
-3. Plot the average weights by species and perhaps by plot_id too.
+3. Plot the average weights by species and perhaps by plot too.
 
 We can automate the process above using Python. It's efficient to spend time
 building the code to perform these tasks because once it's built, we can use it
@@ -130,8 +131,7 @@ in columns. It is similar to a spreadsheet or an SQL table or the `data.frame` i
 R.
 
 First, let's make sure the Python Pandas library is loaded. We will import
-Pandas using the nickname `pd`.  This is a common convention on the internet,
-so if you look up Pandas usage, you will often see it this way.
+Pandas using the nickname `pd`.
 
 ```python
 import pandas as pd
@@ -152,7 +152,7 @@ os.chdir("YOURPathHere")
 
 ```python
 # note that pd.read_csv is used because we imported pandas as pd
-pd.read_csv("surveys.csv")
+pd.read_csv("https://ndownloader.figshare.com/files/2292172")
 ```
 
 The above command yields the **output** below:
@@ -184,7 +184,7 @@ variable name by assigning a value to it using `=`.
 Let's call the imported survey data `surveys_df`:
 
 ```python
-surveys_df = pd.read_csv("surveys.csv")
+surveys_df = pd.read_csv("https://ndownloader.figshare.com/files/2292172")
 ```
 
 Notice when you assign the imported DataFrame to a variable, Python does not

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
-markdown: redcarpet
-redcarpet:
-  extensions: ["tables"]
+markdown: kramdown
+# redcarpet:
+#   extensions: ["tables"]

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
+highlighter: rouge
 markdown: kramdown
-# redcarpet:
-#   extensions: ["tables"]
+kramdown:
+  input: GFM
+  auto_ids: true
+  syntax_highlighter: rouge

--- a/css/lesson.css
+++ b/css/lesson.css
@@ -3,11 +3,6 @@
     color: purple;
 }
 
-/* Highlighted changes in code. */
-.highlight {
-    background-color: mistyrose;
-}
-
 /* Manual input. */
 .in {
     color: darkgreen;


### PR DESCRIPTION
Changes made to _config.yml and to css/lesson.css that will restore the grey background to <pre> blocks when the markdown processor is changed to rouge.  PR submitted per @qjcg and sorry for the noisy entrance here.

If someone could accept or decline as you see fit 

 	20870a0

which was done for instructor training and close all the commits made on Apr 15, I promise to be better about this in future.  Really.

Sorry to be a troublesome rookie.