### PR TITLE
use dict notation for column access

### DIFF
--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -296,6 +296,8 @@ array(['NL', 'DM', 'PF', 'PE', 'DS', 'PP', 'SH', 'OT', 'DO', 'OX', 'SS',
    `plot_names`. How many unique plots are there in the data? How many unique
    species are in the data?
 
+2. What is the difference between `len(plot_names)` and `plot_names.nunique()`?
+
 # Groups in Pandas
 
 We often want to calculate summary statistics grouped by subsets or attributes

--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -277,7 +277,7 @@ Let's get a list of all the species. The `pd.unique` function tells us all of
 the unique values in the `species_id` column.
 
 ```python
-pd.unique(surveys_df.species_id)
+pd.unique(surveys_df['species_id'])
 ```
 
 which **returns**:
@@ -449,7 +449,7 @@ Weight by species plot
 We can also look at how many animals were captured in each plot:
 
 ```python
-total_count=surveys_df.record_id.groupby(surveys_df['plot_id']).nunique()
+total_count = surveys_df['record_id'].groupby(surveys_df['plot_id']).nunique()
 # let's plot that too
 total_count.plot(kind='bar');
 ```


### PR DESCRIPTION
df.colname notation has not been introduced. Using the notations interchangeably is confusing for someone who is new to pandas. 

See issue #87.