### PR TITLE
Fixing typos

### DIFF
--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -16,7 +16,7 @@
   <tr>
     <td class="col-md-1"></td>
     <td class="col-md-3"><a href="{{ page.root }}/setup">Setup</a></td>
-    <td class="col-md-7">Dowload files used on the lesson.</td>
+    <td class="col-md-7">Download files used in the lesson.</td>
   </tr>
   {% for episode in site.episodes %}
     {% if episode.start %} {% comment %} Starting a new day? {% endcomment %}


### PR DESCRIPTION
Have fixed two typos in the naming of the link and issue #136 raised about the set up link that goes nowhere.