### PR TITLE
added github issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+Thank you for filing an issue! 
+
+These lessons are being prepared for publication. From March 15, 2017 to April 21, 2017 issues related to [lesson release preparations](https://github.com/datacarpentry/lesson-release/blob/master/release-checklist.md) are particularly appreciated.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Thank you for your pull request!
+
+These lessons are being prepared for publication and are therefore frozen
+to significant changes in preparation for their release. If you
+are submitting a PR, please make sure it's related to a filed issue.


### PR DESCRIPTION
Added the directory .github with templates for PRs and issues. These templates are for use during the lesson release process to let people know lessons are frozen to significant changes and that we'd appreciate issues related to the lesson release checklist.