### PR TITLE
Installation with ggplot

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -57,8 +57,8 @@ conda install -c conda-forge ggplot
 
 ### Miniconda installation
 
-Miniconda is a "light" version of Anaconda that you can install instead. 
-If you install and use Miniconda you will also need to install the workshop packages.
+Miniconda is an alternative "light" version of Anaconda. 
+If you install and use Miniconda you will also need to install all the workshop packages.
 
 #### Download and install Miniconda
 
@@ -79,6 +79,8 @@ conda list
 From the terminal, type:
 
 ```
+conda create -n py34 python=3.4
+source activate py34
 conda install -y numpy pandas matplotlib jupyter
 conda install -c conda-forge ggplot
 ```

--- a/setup.md
+++ b/setup.md
@@ -33,13 +33,26 @@ Anaconda will install the workshop packages for you.
 
 #### Download and install Anaconda
 
-Download and install [Anaconda](https://www.continuum.io/downloads).
-Remember to download and install the installer for Python 3.x.
+Download and install Anaconda3 version 4.2:
+[Mac](https://repo.continuum.io/archive/Anaconda3-4.2.0-MacOSX-x86_64.pkg)
+[Windows 32 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Windows-x86.exe)
+[Windows 64 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Windows-x86_64.exe)
+[Linux 32 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Linux-x86.sh)
+[Linux 64 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Linux-x86_64.sh)
+Currently, more recent versions of Anaconda does not easily support ggplot.
+
+#### Install ggplot
+
+From the terminal, type:
+
+```
+conda install -c conda-forge ggplot
+```
 
 ### Miniconda installation
 
-Miniconda is a "light" version of Anaconda. If you install and use Miniconda
-you will also need to install the workshop packages.
+Miniconda is a "light" version of Anaconda that you can install instead. 
+If you install and use Miniconda you will also need to install the workshop packages.
 
 #### Download and install Miniconda
 
@@ -55,13 +68,13 @@ From the terminal, type:
 conda list
 ```
 
-### Install the required workshop packages with conda
+#### Install the required workshop packages
 
 From the terminal, type:
 
 ```
 conda install -y numpy pandas matplotlib jupyter
-conda install -c bokeh ggplot
+conda install -c conda-forge ggplot
 ```
 
 ## Launch a Jupyter notebook

--- a/setup.md
+++ b/setup.md
@@ -34,11 +34,17 @@ Anaconda will install the workshop packages for you.
 #### Download and install Anaconda
 
 Download and install Anaconda3 version 4.2:
+
 [Mac](https://repo.continuum.io/archive/Anaconda3-4.2.0-MacOSX-x86_64.pkg)
+
 [Windows 32 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Windows-x86.exe)
+
 [Windows 64 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Windows-x86_64.exe)
+
 [Linux 32 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Linux-x86.sh)
+
 [Linux 64 bit](https://repo.continuum.io/archive/Anaconda3-4.2.0-Linux-x86_64.sh)
+
 Currently, more recent versions of Anaconda does not easily support ggplot.
 
 #### Install ggplot


### PR DESCRIPTION
Currently ggplot is not compatible with python3.6 that is installed with new versions of anaconda.  While there is a solution: https://github.com/datacarpentry/python-ecology-lesson/issues/164, it involves downloading a ton of additional packages (which is difficult to do during a workshop with poor wifi).  I have confirmed that a standard install of Anaconda3-4.2 is compatible with the conda-forge version of ggplot, and think this is the easiest installation solution for now.  I've created a separate issue to discuss improvements to the install process.

I have not been able to find a comparable solution for miniconda, so I included the environment instructions.  This could use more testing.

I also switch contexts from bokeh to conda-forge.  The bokeh version of ggplot is older and does not support the line plot example.