### PR TITLE
simplify commands, clarify slicing, remove index

### DIFF
--- a/_episodes/02-index-slice-subset.md
+++ b/_episodes/02-index-slice-subset.md
@@ -158,6 +158,8 @@ surveys_df[-1]
 ```
 
 # also selects the last element in the list
+# the slice starts at the last element,
+# and ends at the end of the list.
 surveys_df[-1:]
 ```
 

--- a/_episodes/02-index-slice-subset.md
+++ b/_episodes/02-index-slice-subset.md
@@ -154,6 +154,10 @@ languages like Matlab and R.
 surveys_df[:5]
 
 # select the last element in the list
+surveys_df[-1]
+```
+
+# also selects the last element in the list
 surveys_df[-1:]
 ```
 

--- a/_episodes/04-merging-data.md
+++ b/_episodes/04-merging-data.md
@@ -76,8 +76,8 @@ works.
 ```python
 # read in first 10 lines of surveys table
 survey_sub = surveys_df.head(10)
-# grab the last 10 rows (minus the last one)
-survey_sub_last10 = surveys_df[-11:-1]
+# grab the last 10 rows 
+survey_sub_last10 = surveys_df.tail(10)
 #reset the index values to the second dataframe appends properly
 survey_sub_last10=survey_sub_last10.reset_index(drop=True)
 # drop=True option avoids adding new index column with old index values
@@ -110,11 +110,12 @@ have been repeated. We can reindex the new dataframe using the `reset_index()` m
 We can use the `to_csv` command to do export a DataFrame in CSV format. Note that the code
 below will by default save the data into the current working directory. We can
 save it to a different folder by adding the foldername and a slash to the file
-`vertical_stack.to_csv('foldername/out.csv')`.
+`vertical_stack.to_csv('foldername/out.csv')`. We use the 'index=False' so that
+pandas doesn't include the index number for each line.
 
 ```python
 # Write DataFrame to CSV
-vertical_stack.to_csv('out.csv')
+vertical_stack.to_csv('out.csv', index=False)
 ```
 
 Check out your working directory to make sure the CSV wrote out properly, and


### PR DESCRIPTION
Add small clarification for negative index slicing.  Simplify data subset by using 'tail' instead of the confusing all (except last element) slice.  Makes the re-import correct by removing the extraneous index column.