### PR TITLE
Unneeded example complication

### DIFF
--- a/_episodes/01-starting-with-data.md
+++ b/_episodes/01-starting-with-data.md
@@ -254,14 +254,15 @@ Let's begin by exploring our data:
 
 ```python
 # Look at the column names
-surveys_df.columns.values
+surveys_df.columns
 ```
 
 which **returns**:
 
 ```
-array(['record_id', 'month', 'day', 'year', 'plot_id', 'species_id', 'sex',
-       'hindfoot_length', 'weight'], dtype=object)
+Index(['record_id', 'month', 'day', 'year', 'plot_id', 'species_id', 'sex',
+       'hindfoot_length', 'weight'],
+      dtype='object')
 ```
 
 Let's get a list of all the species. The `pd.unique` function tells us all of


### PR DESCRIPTION
Using `survey_df.columns.values` instead of simply  `survey_df.columns` triggers a question "what is the meaning of 'values' and why do we need that". We don't actually need `.values` in this case, so I suggest removing it.


Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
