### PR TITLE
Fixed a mix-up in `loc` and `iloc` inclusiveness

### DIFF
--- a/_episodes/02-index-slice-subset.md
+++ b/_episodes/02-index-slice-subset.md
@@ -280,8 +280,8 @@ surveys_df.loc[[0, 10, 35549], :]
 **NOTE**: Labels must be found in the DataFrame or you will get a `KeyError`.
 
 Indexing by labels `loc` differs from indexing by integers `iloc`.
-With `iloc`, the start bound and the stop bound are **inclusive**. When using
-`loc` instead, integers *can* also be used, but the integers refer to the
+With `loc`, the both start bound and the stop bound are **inclusive**. When using
+`loc`, integers *can* be used, but the integers refer to the
 index label and not the position. For example, using `loc` and select 1:4
 will get a different result than using `iloc` to select rows 1:4.
 


### PR DESCRIPTION
The text said

>  With iloc, the start bound and the stop bound are inclusive.

which is not true. Fixed


Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
