### PR TITLE
Introduce type function earlier + some wording changes

### DIFF
--- a/_episodes/00-short-introduction-to-Python.md
+++ b/_episodes/00-short-introduction-to-Python.md
@@ -56,8 +56,7 @@ Hello World
 
 ### Strings, integers and floats
 
-Python has built-in numeric types for integers, floats, and complex numbers.
-Strings are a built-in textual type.:
+One of the most basic things we can do in Python is assign values to variables:
 
 ```python
 text = "Data Carpentry"
@@ -65,19 +64,41 @@ number = 42
 pi_value = 3.1415
 ```
 
-Here we've assigned data to variables, namely `text`, `number` and `pi_value`,
-using the assignment operator `=`. The variable called `text` is a string which
-means it can contain letters and numbers. Notice that in order to define a
-string you need to have quotes around your text. To print out the value
-stored in a variable we can simply type the name of the variable into the
-interpreter:
+Here we've assigned data to the variables `text`, `number` and `pi_value`,
+using the assignment operator `=`. To review the value of a variable, we
+can type the name of the variable into the interpreter and press `Enter`:
 
 ```python
 >>> text
 "Data Carpentry"
 ```
 
-However, in a script, a `print` function is needed to output the `text`:
+Everything in Python has a type. To get the type of something, we can pass it
+to the built-in function `type`:
+
+```python
+>>> type(text)
+<class 'str'>
+>>> type(number)
+<class 'int'>
+>>> type(6.02)
+<class 'float'>
+```
+
+The variable `text` is of type `str`, short for "string". Strings hold
+sequences of characters, which can be letters, numbers, punctuation
+or more exotic forms of text (even emoji!).
+
+We can also see the value of something using another built-in function, `print`:
+
+```python
+>>> print(text)
+Data Carpentry
+>>> print(11)
+11
+```
+
+This may seem redundant, but in fact it's the only way to display output in a script:
 
 *example.py*
 ```python
@@ -85,7 +106,9 @@ However, in a script, a `print` function is needed to output the `text`:
 # Comments in Python start with #
 # The next line assigns the string "Data Carpentry" to the variable "text".
 text = "Data Carpentry"
-# The next line uses the print function to print out the text string
+# The next line does nothing!
+text
+# The next line uses the print function to print out the value we assigned to "text"
 print(text)
 ```
 *Running the script*
@@ -94,7 +117,9 @@ $ python example.py
 Data Carpentry
 ```
 
-**Tip**: The `print` function is a built-in function in Python. Later in this
+Notice that "Data Carpentry" is printed only once. 
+
+**Tip**: `print` and `type` are built-in functions in Python. Later in this
 lesson, we will introduce methods and user-defined functions. The Python
 documentation is excellent for reference on the differences between them.
 

--- a/_episodes/01-starting-with-data.md
+++ b/_episodes/01-starting-with-data.md
@@ -166,7 +166,7 @@ surveys_df = pd.read_csv("surveys.csv")
 ```
 
 Notice when you assign the imported DataFrame to a variable, Python does not
-produce any output on the screen. We can print the value of the `surveys_df`
+produce any output on the screen. We can view the value of the `surveys_df`
 object by typing its name into the Python command prompt.
 
 ```python
@@ -175,27 +175,23 @@ surveys_df
 
 which prints contents like above
 
-## Manipulating Our Species Survey Data
+## Exploring Our Species Survey Data
 
-Now we can start manipulating our data. First, let's check the data type of the
-data stored in `surveys_df` using the `type` method. **The `type` method and
-`__class__` attribute** tell us that `surveys_df` is `<class 'pandas.core.frame.DataFrame'>`.
+Again, we can use the `type` function to see what kind of thing `surveys_df` is:
 
 ```python
-type(surveys_df)
-# this does the same thing as the above!
-surveys_df.__class__
+>>> type(surveys_df)
+<class 'pandas.core.frame.DataFrame'>
 ```
-We can also enter `surveys_df.dtypes` at our prompt to view the data type for each
-column in our DataFrame. `int64` represents numeric integer values - `int64` cells
-can not store decimals. `object` represents strings (letters and numbers). `float64`
-represents numbers with decimals.
 
-	surveys_df.dtypes
+As expected, it's a DataFrame (or, to use the full name that Python uses to refer
+to it internally, a `pandas.core.frame.DataFrame`).
 
-which returns:
+What kind of things does `surveys_df` contain? DataFrames have an attribute
+called `dtypes` that answers this:
 
-```
+```python
+>>> surveys_df.dtypes
 record_id            int64
 month                int64
 day                  int64
@@ -207,6 +203,12 @@ hindfoot_length    float64
 weight             float64
 dtype: object
 ```
+
+All the values in a column have the same type. For example, months have type
+`int64`, which is a kind of integer. Cells in the month column cannot have
+fractional values, but the weight and hindfoot_length columns can, because they
+have type `float64`. The `object` type doesn't have a very helpful name, but in
+this case it represents strings (such as 'M' and 'F' in the case of sex).
 
 We'll talk a bit more about what the different formats mean in a different lesson.
 


### PR DESCRIPTION
The main goal in this P.R. was to introduce the `type()` function earlier (in the 1st lesson rather than the 2nd). It's a pretty useful tool for Python learners, and the idea of types is already being discussed in the 1st lesson.

I also wanted to remove the references to `__class__` from the second lesson. I think it's probably too advanced and doesn't add anything beyond `type`.

The rest is mostly incidental wording changes I made while I was in the neighborhood, which I hope are improvements. 
