### PR TITLE
Fix rendering of some pages

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: "Contributor Code of Conduct"
-permalink: /conduct/
 ---
+
 As contributors and maintainers of this project,
 we pledge to follow the [Carpentry Code of Conduct][coc].
 

--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
 ---
 
 ## Glossary

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,6 @@
 ---
 layout: page
 title: Setup
-permalink: /setup/
 ---
 
 > ## Data


### PR DESCRIPTION
Right now these pages do not render correctly:

http://www.datacarpentry.org/python-ecology-lesson/reference/
http://www.datacarpentry.org/python-ecology-lesson/setup/
http://www.datacarpentry.org/python-ecology-lesson/conduct/

Removing "permalink" from the header seems to work. I also don't see permalink being specified in the lesson-example:

https://github.com/carpentries/lesson-example