### PR TITLE
01-short-introduction-to-Python.md: reference value in dict by key and not position

### DIFF
--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -450,7 +450,7 @@ for key in rev.keys():
 > ## Changing dictionaries
 >
 > 1. First, print the value of the `rev` dictionary to the screen.
-> 2. Reassign the second value (in the *key value pair*) so that it no longer
+> 2. Reassign the value that corresponds to the key "2" so that it no longer
 >    reads "two" but instead "apple-sauce".
 > 3. Print the value of `rev` to the screen again to see if the value has changed.
 >

--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -450,7 +450,7 @@ for key in rev.keys():
 > ## Changing dictionaries
 >
 > 1. First, print the value of the `rev` dictionary to the screen.
-> 2. Reassign the value that corresponds to the key "2" so that it no longer
+> 2. Reassign the value that corresponds to the key `2` so that it no longer
 >    reads "two" but instead "apple-sauce".
 > 3. Print the value of `rev` to the screen again to see if the value has changed.
 >


### PR DESCRIPTION
Refers to #335 - `dict` values should never be referred to by position, but by key.
