### PR TITLE
03-index-slice-subset.md: use proper dataframe name

### DIFF
--- a/_episodes/03-index-slice-subset.md
+++ b/_episodes/03-index-slice-subset.md
@@ -348,8 +348,8 @@ selects the element that is 3 rows down and 7 columns over in the DataFrame.
 >
 > 2. What happens when you call:
 >
->    - `dat.iloc[0:4, 1:4]`
->    - `dat.loc[0:4, 1:4]`
+>    - `surveys_df.iloc[0:4, 1:4]`
+>    - `surveys_df.loc[0:4, 1:4]`
 >
 > - How are the two commands different?
 {: .challenge}


### PR DESCRIPTION
Replaced generic dataframe name `df` by lesson-specific `surveys_df`