### PR TITLE
clean up formatting in episode 08-putting-it-all-together

### DIFF
--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -297,7 +297,6 @@ plt.show() # not necessary in Jupyter Notebooks
 > > flood.plot(x ="datetime", y="flow_rate", ax=ax)
 > > discharge.plot(x ="datetime", y="flow_rate", ax=ax2)
 > > ax2.legend().set_visible(False)
-
 > > ax.set_xlabel("") # no label
 > > ax.set_ylabel("Discharge, cubic feet per second")
 > > ax.legend().set_visible(False)

--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -317,8 +317,9 @@ fig.savefig("my_plot_name.png")
 ~~~
 {: .language-python}
 
-Which will save the `fig` created using Pandas/matplotlib as a png file with the name `my_plot_name`
+which will save the `fig` created using Pandas/matplotlib as a png file with the name `my_plot_name`
 
+> ## Tip: Saving figures in different formats
 > ~~~
 >     Matplotlib recognizes the extension used in the filename and
 >     supports (on most computers) png, pdf, ps, eps and svg formats.

--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -321,8 +321,8 @@ which will save the `fig` created using Pandas/matplotlib as a png file with the
 
 > ## Tip: Saving figures in different formats
 > ~~~
->     Matplotlib recognizes the extension used in the filename and
->     supports (on most computers) png, pdf, ps, eps and svg formats.
+> Matplotlib recognizes the extension used in the filename and
+> supports (on most computers) png, pdf, ps, eps and svg formats.
 > ~~~
 {: .callout}
 

--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -320,10 +320,8 @@ fig.savefig("my_plot_name.png")
 which will save the `fig` created using Pandas/matplotlib as a png file with the name `my_plot_name`
 
 > ## Tip: Saving figures in different formats
-> ~~~
 > Matplotlib recognizes the extension used in the filename and
 > supports (on most computers) png, pdf, ps, eps and svg formats.
-> ~~~
 {: .callout}
 
 > ## Challenge - Saving figure to file

--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -292,9 +292,9 @@ plt.show() # not necessary in Jupyter Notebooks
 > > fig, ax = plt.subplots()
 > > flood = discharge[(discharge["datetime"] >= "2013-09-11") &
                         (discharge["datetime"] < "2013-09-15")]
->>
+> >
 > > ax2 = fig.add_axes([0.65, 0.575, 0.25, 0.3])
->> flood.plot(x ="datetime", y="flow_rate", ax=ax)
+> > flood.plot(x ="datetime", y="flow_rate", ax=ax)
 > > discharge.plot(x ="datetime", y="flow_rate", ax=ax2)
 > > ax2.legend().set_visible(False)
 
@@ -357,4 +357,3 @@ save as a text file with a `.py` extension and run in the command line).
 {: .challenge}
 
 {% include links.md %}
-


### PR DESCRIPTION
This pull request addresses some distracting formatting issues in [Episode 8](https://datacarpentry.org/python-ecology-lesson/08-putting-it-all-together/index.html):

* Near the bottom of the page, under the header *Challenge - Pandas and matplotlib*, the challenge and answer are not rendered properly. This was due to a line break in the middle of the answer.

* Just below that, under the header *Saving matplotlib figures*, the tip is not formatted correctly and the text is rendered as code.