### PR TITLE
01-short-introduction-to-Python.md: Add missing quotation mark

### DIFF
--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -14,7 +14,7 @@ keypoints:
     - "Python is an interpreted language which can be used interactively (executing one command at a time) or in scripting mode (executing a series of commands saved in file)."
     - "One can assign a value to a variable in Python. Those variables can be of several types, such as string, integer, floating point and complex numbers."
     - "Lists and tuples are similar in that they are ordered lists of elements; they differ in that a tuple is immutable (cannot be changed)."
-    - "Dictionaries are unordered data structures that provide mappings between keys and values.
+    - "Dictionaries are unordered data structures that provide mappings between keys and values."
 ---
 
 ## Interpreter


### PR DESCRIPTION
A missing quote at the end of the YAML in section 01 meant it wasn't being read and didn't show up on the table in the home page