### PR TITLE
Use GitHub link instead of "DownGit" service

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -9,7 +9,7 @@ title: Setup
 >
 > We will use the six files listed below for the data in this lesson.
 > Download these files to your computer either by clicking
-> [this link](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/weecology/portal-teachingdb),
+> [this link](https://github.com/weecology/portal-teachingdb/archive/master.zip),
 > which will give you everything in a single compressed file.
 > You'll need to unzip this file after downloading it.
 >


### PR DESCRIPTION
I don't understand why this was done in #231. GitHub has built-in download links, I was surprised to see this fancy JavaScript service being used for this.

This seems like a 404 waiting to happen, and can't be good for accessibility.

[This is what DownGit itself uses anyway](https://github.com/MinhasKamal/DownGit/blob/def14cef2a5d9fe4bef3227c38de425e5c145c60/app/home/down-git.js#L152-L153):
```javascript
var downloadUrl = "https://github.com/"+repoInfo.author+"/"+
    repoInfo.repository+"/archive/"+repoInfo.branch+".zip";
```