### PR TITLE
Removing unnecessary `

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -113,7 +113,7 @@ Both do result in the same output, making it alternative ways of getting the uni
 ~~~
 surveys_df.groupby(['plot_id','sex']).agg({"year": 'min',
                                            "hindfoot_length": 'median',
-                                           "weight": 'mean'})`
+                                           "weight": 'mean'})
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
In the instructor notes, there is an extra ` in one of the commands