### PR TITLE
01-short-introduction-to-Python.md: remove statement about order in Python dicts

### DIFF
--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -459,13 +459,6 @@ for key in rev.keys():
 >
 {: .challenge}
 
-It is important to note that dictionaries are "unordered" and do not remember
-the sequence of their items (i.e. the order in which key:value pairs were
-added to the dictionary). Because of this, the order in which items are
-returned from loops over dictionaries might appear random and can even change
-with time.
-
-
 
 ## Functions
 


### PR DESCRIPTION
I suggest removing the statement about the order in Python dictionaries. The behavior has changed between Python 3.5, 3.6, and 3.7 and it would be a bit too difficult to explain.