### PR TITLE
Fix typo that shows a wrong value of the `number` variable.

### DIFF
--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -148,7 +148,7 @@ print(number)
 ~~~
 {: .language-python}
 ~~~
-11
+42
 ~~~
 {: .output}
 


### PR DESCRIPTION
There is a typo/error within the file. The value of the `number`
variable is set to `42` on line 84. However, the line `151` shows `11`
instead of `42`. This might be confusing to people/instructors.