### PR TITLE
fix formatting

### DIFF
--- a/_episodes/03-index-slice-subset.md
+++ b/_episodes/03-index-slice-subset.md
@@ -113,8 +113,9 @@ the related Python data type dictionary).
 {: .callout}
 
 Let's remind ourselves that Python uses 0-based
-indexing. This means that the first element in an object is located at position
-0. This is different from other tools like R and Matlab that index elements
+indexing. This means that the first element in an object is located at position 0. 
+
+This is different from other tools like R and Matlab that index elements
 within objects starting at 1.
 
 ~~~


### PR DESCRIPTION
`md` formatting made the sentence ending "located at position 0." read as beginning an ordered list.  This PR fixes that formatting. 