### PR TITLE
Introducing len() built-in python function

### DIFF
--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -360,6 +360,9 @@ a_list = [1, 2, 3]
 > 1. What happens when you execute `a_list[1] = 5`?
 > 2. What happens when you execute `a_tuple[2] = 5`?
 > 3. What does `type(a_tuple)` tell you about `a_tuple`?
+> 4. What information does the built-in function `len()` provide?
+     Does it provide the same information on both tuples and lists?
+     Does the `help()` function confirm this?
 {: .challenge}
 
 


### PR DESCRIPTION
Making changes as suggested by @wrightaprilm and @maxim-belkin. Added an extra question introducing the built-in len() function in lesson 1, and also emphasizing that both lists and tuples are iterable types, just that tuples are immutable.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
