### PR TITLE
guide.md: remove space after comma in 'Basic Loop Challenges'

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -486,7 +486,7 @@ concatenate strings using a plus sign. For example, `print(string1 + string2)` o
 
 ~~~
 for creature in animals:
-    print(creature+', ', end='')
+    print(creature + ',', end='')
 ~~~
 {: .language-python}
 


### PR DESCRIPTION
Have to undo one recent change introduced in #435 in order to keep the section consistent with what it was doing before. Also, while at it, add spaces around `+`.

@katrinleinweber, LGTY?