### PR TITLE
Adding extended setup instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -82,10 +82,10 @@ If you run into any difficulties, please request help before the workshop begins
     d.  Press <kbd>Return</kbd>.
 
     e.  Follow the text-only prompts.  When the license agreement appears (a colon
-        will be present at the bottom of the screen) press the space bar until you see the 
-        bottom of the text. Type `yes` and press enter to approve the license. Press 
-        enter again to approve the default location for the files. Type `yes` and 
-        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda 
+        will be present at the bottom of the screen) press <kbd>Spacebar</kbd> until you see the 
+        bottom of the text. Type `yes` and press <kbd>Return</kbd> to approve the license. Press 
+        <kbd>Return</kbd> again to approve the default location for the files. Type `yes` and 
+        press <kbd>Return</kbd> to prepend Anaconda to your `PATH` (this makes the Anaconda 
         distribution your user's default Python).
 
 

--- a/setup.md
+++ b/setup.md
@@ -22,8 +22,6 @@ title: Setup
 > this file after downloading it.
 {: .prereq}
 
-
-
 > ## Installing Python using Anaconda
 > [Python][python] is a popular language for scientific computing, and great for
 > general-purpose programming as well. Installing all of its scientific packages

--- a/setup.md
+++ b/setup.md
@@ -48,7 +48,7 @@ title: Setup
 
 ### Mac OS X - [Video tutorial][video-mac]
 
-1. Visit [https://www.anaconda.com/distribution/][anaconda-mac] with your web browser.
+1. Visit <https://www.anaconda.com/products/individual> in your web browser.
 
 2. Download the Python 3 installer for OS X. These instructions assume that you use the graphical installer `.pkg` file.
 

--- a/setup.md
+++ b/setup.md
@@ -150,7 +150,9 @@ conda install -y package_name
 ~~~
 {: .language-bash}
 
-You may need to install the required packages in this way, if you opted for installing Miniconda, instead of Anaconda. Miniconda is a "light" version of Anaconda. If you install and use Miniconda
+You may need to install the required packages in this way,
+if you opted for installing Miniconda, instead of Anaconda.
+Miniconda is a lightweight version of Anaconda. If you install and use Miniconda
 you will also need to install the workshop packages manually in the following way:
 ~~~
 conda install -y numpy pandas matplotlib jupyter

--- a/setup.md
+++ b/setup.md
@@ -22,17 +22,16 @@ title: Setup
 > this file after downloading it.
 {: .prereq}
 
+
+
 > ## Installing Python using Anaconda
 > [Python][python] is a popular language for scientific computing, and great for
-> general-purpose programming as well. Installing all of its scientific packages
-> individually can be a bit difficult, however, so we recommend the all-in-one
+> general-purpose programming as well. Installing all of the scientific packages we use in the lesson
+> individually can be a bit cumbersome, and therefore recommend the all-in-one
 > installer [Anaconda][anaconda].
 >
 > Regardless of how you choose to install it, please make sure you install Python
-> version 3.x (e.g., 3.6 is fine). Also, please set up your Python environment at 
-> least a day in advance of the workshop.  If you encounter problems with the 
-> installation procedure, ask your workshop organizers via e-mail for assistance so
-> you are ready to go as soon as the workshop begins.
+> version 3.x (e.g., 3.6 is fine). 
 {: .prereq}
 
 ### Windows - [Video tutorial][video-windows]

--- a/setup.md
+++ b/setup.md
@@ -39,7 +39,7 @@ title: Setup
 
 ### Windows - [Video tutorial][video-windows]
 
-1. Open [https://www.anaconda.com/distribution/][anaconda-windows] with your web browser.
+1. Open <https://www.anaconda.com/products/individual> in your web browser.
 
 2. Download the Python 3 installer for Windows.
 

--- a/setup.md
+++ b/setup.md
@@ -127,10 +127,10 @@ conda --help
 ## Required Python Packages for this Workshop
 The following are packages needed for this workshop:
 
-* [Pandas](http://pandas.pydata.org/)
-* [Jupyter notebook](http://jupyter.org/)
-* [Numpy](http://www.numpy.org/)
-* [Matplotlib](http://matplotlib.org/)
+* [Pandas](https://pandas.pydata.org/)
+* [Jupyter notebook](https://jupyter.org/)
+* [Numpy](https://numpy.org/)
+* [Matplotlib](https://matplotlib.org/)
 * [Plotnine](https://plotnine.readthedocs.io/en/stable/)
 
 All packages apart from plotnine will have automatically been installed with Anaconda and we can use anaconda as a package manager to install the missing `plotnine` package:

--- a/setup.md
+++ b/setup.md
@@ -75,7 +75,7 @@ If you run into any difficulties, please request help before the workshop begins
     ~~~
     $ bash Anaconda3-
     ~~~
-    {: .bash}
+    {: .language-bash}
 
     and press tab.  The name of the file you just downloaded should appear.
 

--- a/setup.md
+++ b/setup.md
@@ -60,7 +60,7 @@ title: Setup
 Note that the following installation steps require you to work from the terminal (shell). 
 If you run into any difficulties, please request help before the workshop begins.
 
-1.  Open [https://www.anaconda.com/distribution/][anaconda-linux] with your web browser.
+1.  Open <https://www.anaconda.com/products/individual> in your web browser.
 
 2.  Download the Python 3 installer for Linux.
 
@@ -73,11 +73,11 @@ If you run into any difficulties, please request help before the workshop begins
     c.  Type
 
     ~~~
-    $ bash Anaconda3-
+    bash Anaconda3-
     ~~~
     {: .language-bash}
 
-    and press tab.  The name of the file you just downloaded should appear.
+    and press <kbd>Tab</kbd>.  The name of the file you just downloaded should appear.
 
     d.  Press <kbd>Return</kbd>.
 

--- a/setup.md
+++ b/setup.md
@@ -90,11 +90,8 @@ If you run into any difficulties, please request help before the workshop begins
 
 
 [anaconda]: https://www.anaconda.com/
-[anaconda-mac]: https://www.anaconda.com/download/#macos
-[anaconda-linux]: https://www.anaconda.com/download/#linux
-[anaconda-windows]: https://www.anaconda.com/download/#windows
-[jupyter]: http://jupyter.org/
-[python]: https://python.org
+[jupyter]: https://jupyter.org/
+[python]: https://www.python.org/
 [video-mac]: https://www.youtube.com/watch?v=TcSAln46u9U
 [video-windows]: https://www.youtube.com/watch?v=xxQ0mzZ8UvA
 

--- a/setup.md
+++ b/setup.md
@@ -79,7 +79,7 @@ If you run into any difficulties, please request help before the workshop begins
 
     and press tab.  The name of the file you just downloaded should appear.
 
-    d.  Press enter.
+    d.  Press <kbd>Return</kbd>.
 
     e.  Follow the text-only prompts.  When the license agreement appears (a colon
         will be present at the bottom of the screen) press the space bar until you see the 

--- a/setup.md
+++ b/setup.md
@@ -24,77 +24,143 @@ title: Setup
 
 
 
-> ## Software
-> [Python](http://python.org) is a popular language for
-> scientific computing, and great for general-purpose programming as
-> well.  Installing all of its scientific packages individually can be
-> a bit difficult, so we recommend an all-in-one installer.
+> ## Installing Python using Anaconda
+> [Python][python] is a popular language for scientific computing, and great for
+> general-purpose programming as well. Installing all of its scientific packages
+> individually can be a bit difficult, however, so we recommend the all-in-one
+> installer [Anaconda][anaconda].
 >
-> For this workshop we use Python version 3.x.
->
-> ### Required Python Packages for this workshop
->
-> * [Pandas](http://pandas.pydata.org/)
-> * [Jupyter notebook](http://jupyter.org/)
-> * [Numpy](http://www.numpy.org/)
-> * [Matplotlib](http://matplotlib.org/)
+> Regardless of how you choose to install it, please make sure you install Python
+> version 3.x (e.g., 3.6 is fine). Also, please set up your Python environment at 
+> least a day in advance of the workshop.  If you encounter problems with the 
+> installation procedure, ask your workshop organizers via e-mail for assistance so
+> you are ready to go as soon as the workshop begins.
 {: .prereq}
 
-## Install the workshop packages
+### Windows - [Video tutorial][video-windows]
 
-For installing these packages we will use Anaconda or Miniconda.
-They both use [Conda](https://conda.io/en/latest/), the main difference is
-that Anaconda comes with a lot of packages pre-installed.
-With Miniconda you will need to install the required packages.
+1. Open [https://www.anaconda.com/distribution/][anaconda-windows] with your web browser.
 
-### Anaconda installation
+2. Download the Python 3 installer for Windows.
 
-Anaconda will install the workshop packages for you.
+3. Double-click the executable and install Python 3 using the recommended settings. Make sure that **Register Anaconda as my default Python 3.x** option is checked - it should be in the latest version of Anaconda
 
-#### Download and install Anaconda
 
-Download and install [Anaconda](https://www.anaconda.com/distribution/#download-section).
-Remember to download and install the installer for Python 3.x.
+### Mac OS X - [Video tutorial][video-mac]
 
-#### Download plotting package
+1. Visit [https://www.anaconda.com/distribution/][anaconda-mac] with your web browser.
 
-The plotting package plotnine is not installed by default.  From the terminal,
-type:
+2. Download the Python 3 installer for OS X. These instructions assume that you use the graphical installer `.pkg` file.
+
+3. Follow the Python 3 installation instructions. Make sure that the install location is set to "Install only for me" so Anaconda will install its files locally, relative to your home directory. Installing the software for all users tends to create problems in the long run and should be avoided.
+
+
+### Linux
+
+Note that the following installation steps require you to work from the terminal (shell). 
+If you run into any difficulties, please request help before the workshop begins.
+
+1.  Open [https://www.anaconda.com/distribution/][anaconda-linux] with your web browser.
+
+2.  Download the Python 3 installer for Linux.
+
+3.  Install Python 3 using all of the defaults for installation.
+
+    a.  Open a terminal window.
+
+    b.  Navigate to the folder where you downloaded the installer
+
+    c.  Type
+
+    ~~~
+    $ bash Anaconda3-
+    ~~~
+    {: .bash}
+
+    and press tab.  The name of the file you just downloaded should appear.
+
+    d.  Press enter.
+
+    e.  Follow the text-only prompts.  When the license agreement appears (a colon
+        will be present at the bottom of the screen) press the space bar until you see the 
+        bottom of the text. Type `yes` and press enter to approve the license. Press 
+        enter again to approve the default location for the files. Type `yes` and 
+        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda 
+        distribution your user's default Python).
+
+
+[anaconda]: https://www.anaconda.com/
+[anaconda-mac]: https://www.anaconda.com/download/#macos
+[anaconda-linux]: https://www.anaconda.com/download/#linux
+[anaconda-windows]: https://www.anaconda.com/download/#windows
+[jupyter]: http://jupyter.org/
+[python]: https://python.org
+[video-mac]: https://www.youtube.com/watch?v=TcSAln46u9U
+[video-windows]: https://www.youtube.com/watch?v=xxQ0mzZ8UvA
+
+## Opening a Conda-enabled Terminal and Verifying the Installation:
+
+### Windows
+Click Start, search, or select Anaconda Prompt from the menu. A window should pop up where you can now type commands such as checking your Conda installation with:
 
 ~~~
-conda install -c conda-forge plotnine
+conda --help
 ~~~
 {: .language-bash}
 
-### Miniconda installation
+### Mac OSX
 
-Miniconda is a "light" version of Anaconda. If you install and use Miniconda
-you will also need to install the workshop packages.
-
-#### Download and install Miniconda
-
-Download and install [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
-following the instructions. Remember to download and run the installer for
-Python 3.x.
-
-#### Check the installation of Miniconda
-
-From the terminal, type:
+Click the Launchpad icon in the Dock, type Terminal in the search field, then click Terminal. 
+A window should pop up where you can now type commands such as checking your conda installation with:
 
 ~~~
-conda list
+conda --help
 ~~~
 {: .language-bash}
 
-### Install the required workshop packages with conda
+### Linux
+This depends a bit on your Linux distribution, but often you will have an Applications listing in which you can select a Terminal icon you can click. A window should pop up where you can now type commands such as checking your conda installation with:
 
-From the terminal, type:
+~~~
+conda --help
+~~~
+{: .language-bash}
 
+
+## Required Python Packages for this Workshop
+The following are packages needed for this workshop:
+
+* [Pandas](http://pandas.pydata.org/)
+* [Jupyter notebook](http://jupyter.org/)
+* [Numpy](http://www.numpy.org/)
+* [Matplotlib](http://matplotlib.org/)
+* [Plotnine](https://plotnine.readthedocs.io/en/stable/)
+
+All packages apart from plotnine will have automatically been installed with Anaconda and we can use anaconda as a package manager to install the missing `plotnine` package:
+You need to open up a *Terminal*, if you are using Mac OSX, or Linux (see instructions above), or launch an *anaconda-promt*, if you are using Windows. In your terminal window type the following: 
+
+~~~
+conda install -y -c conda-forge plotnine
+~~~
+{: .language-bash}
+
+This will then install the latest version of plotnine into your conda environment. 
+
+## Installing other Packages (Not required)
+If you want to install any additional packages, you can do so by opening a terminal window and type:
+~~~
+conda install -y package_name
+~~~
+{: .language-bash}
+
+You may need to install the required packages in this way, if you opted for installing Miniconda, instead of Anaconda. Miniconda is a "light" version of Anaconda. If you install and use Miniconda
+you will also need to install the workshop packages manually in the following way:
 ~~~
 conda install -y numpy pandas matplotlib jupyter
 conda install -c conda-forge plotnine
 ~~~
 {: .language-bash}
+
 
 ## Launch a Jupyter notebook
 


### PR DESCRIPTION
@maxim-belkin, I have made an attempt at improving the instructions for setup I had raised as #457. Some of it is directly copied from the Software carpentry setup instructions including the setup videos. Other bits I added myself. 

Let me know if you want me to change anything further. 

It may also be nice to change the html template for Python for DC lessons to look a bit more like the SC ones such as this one:
https://edcarp.github.io/2020-01-21-edinburgh-swc/

But I think this will require the change of the actual workshop-template.  
