### PR TITLE
PR to address issue #471

### DIFF
--- a/_episodes/00-before-we-start.md
+++ b/_episodes/00-before-we-start.md
@@ -104,7 +104,7 @@ For example, you can store raw data in files `./data/raw/` and clean data in `./
 
 - **`documents/`**: Use this folder to store outlines, drafts, and other text.
 
-- **`scripts/`**: Use this folder to store your (Python) scripts for data cleaning, analysis, and
+- **`code/`**: Use this folder to store your (Python) scripts for data cleaning, analysis, and
 plotting that you use in this particular project.
 
 You may need to create additional directories depending on your project needs, but these should form


### PR DESCRIPTION
Changes folder in the introductory suggested project layout from **scripts** to **code**

Referenced in issue #471, the *Before we start* episode 0 suggests keeping Python code in a **scripts** folder.
Unfortunately, Anaconda has a built-in `scripts` module that will shadow the student's **scripts** folder and make
```
import scripts.example
```
fail.

The issue suggests adding an `__init__.py` to **scripts**.
That adds unnecessary complexity to the introductory material and this PR proposes renaming the folder.