### PR TITLE
Fix typo in Indexing, Slicing & Subsetting episode

### DIFF
--- a/_episodes/03-index-slice-subset.md
+++ b/_episodes/03-index-slice-subset.md
@@ -247,7 +247,7 @@ surveys_df.head()
 
 What is the difference between these two dataframes?
 
-When we assigned the first 3 columns the value of `0` using the
+When we assigned the first 3 rows the value of `0` using the
 `ref_surveys_df` DataFrame, the `surveys_df` DataFrame is modified too.
 Remember we created the reference `ref_survey_df` object above when we did
 `ref_survey_df = surveys_df`. Remember `surveys_df` and `ref_surveys_df`


### PR DESCRIPTION
Comment & code refers to *rows* while text mistakenly refers to *columns*

Fix to #479
