### PR TITLE
Change IPython Notebook to Jupyter Notebook

### DIFF
--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -37,7 +37,7 @@ and they can replicate the same analysis.
 
 To help the lesson run smoothly, let's ensure everyone is in the same directory.
 This should help us avoid path and file name issues. At this time please
-navigate to the workshop directory. If you are working in IPython Notebook be sure
+navigate to the workshop directory. If you are working in Jupyter Notebook be sure
 that you start your notebook in the workshop directory.
 
 A quick aside that there are Python libraries like [OS Library][os-lib] that can work with our

--- a/_episodes/06-loops-and-functions.md
+++ b/_episodes/06-loops-and-functions.md
@@ -453,7 +453,7 @@ yearly_data_csv_writer(1977, 2002, surveys_df)
 ~~~
 {: .language-python}
 
-BEWARE! If you are using IPython Notebooks and you modify a function, you MUST
+BEWARE! If you are using Jupyter Notebooks and you modify a function, you MUST
 re-run that cell in order for the changed function to be available to the rest
 of the code. Nothing will visibly happen when you do this, though, because
 defining a function without *calling* it doesn't produce an output. Any

--- a/_episodes/08-putting-it-all-together.md
+++ b/_episodes/08-putting-it-all-together.md
@@ -47,7 +47,7 @@ either a shell script or Python to do this - you wouldn't want to do it by hand
 if you had many files to process.
 
 If you are still having trouble importing the data as a table using Pandas,
-check the documentation. You can open the docstring in an ipython notebook using
+check the documentation. You can open the docstring in a Jupyter Notebook using
 a question mark. For example:
 
 ~~~
@@ -359,7 +359,7 @@ which will save the `fig` created using Pandas/matplotlib as a png file with the
 
 Matplotlib can make many other types of plots in much the same way that it makes two-dimensional line plots. Look through the examples in
 <http://matplotlib.org/users/screenshots.html> and try a few of them (click on the
-"Source code" link and copy and paste into a new cell in ipython notebook or
+"Source code" link and copy and paste into a new cell in Jupyter Notebook or
 save as a text file with a `.py` extension and run in the command line).
 
 > ## Challenge - Final Plot


### PR DESCRIPTION
<details>
As requested by maxim-belkin in [issue 364](https://github.com/datacarpentry/python-ecology-lesson/issues/364), I changed mentions of "IPython Notebook" to "Jupyter Notebook" to maintain consistency throughout the whole lesson.
</details>
