### PR TITLE
Using display() command instead of print() in 02-starting-with-data and added assignment of data types

### DIFF
--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -534,7 +534,7 @@ ways, but we'll use `groupby` combined with **a `count()` method**.
 ~~~
 # Count the number of samples by species
 species_counts = surveys_df.groupby('species_id')['record_id'].count()
-print(species_counts)
+display(species_counts)
 ~~~
 {: .language-python}
 

--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -317,6 +317,30 @@ fractional values, but the weight and hindfoot_length columns can, because they
 have type `float64`. The `object` type doesn't have a very helpful name, but in
 this case it represents strings (such as 'M' and 'F' in the case of sex).
 
+The datatypes can be adjusted in order to save memory for large data frames. The datatype `category` is useful for string variables consisting of only a few different values such as 'M' and 'F' in the case of sex. New datatypes can be assigned by:
+
+~~~
+new_types = {'record_id': 'int32', 'month': 'int16', 'day': 'int16', 'year': 'int16', 'plot_id': 'int16',
+             'species_id' : 'object','sex': 'category', 'hindfoot_length': 'float32', 'weight': 'float32'}
+surveys_df = surveys_df.astype(new_types)
+display(surveys_df.dtypes)
+~~~
+{: .language-python}
+~~~
+record_id             int32
+month                 int16
+day                   int16
+year                  int16
+plot_id               int16
+species_id           object
+sex                category
+hindfoot_length     float32
+weight              float32
+dtype: object
+~~~
+{: .output}
+
+
 We'll talk a bit more about what the different formats mean in a different lesson.
 
 ### Useful Ways to View DataFrame objects in Python

--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -460,15 +460,24 @@ numeric data.
 
 ~~~
 # Summary statistics for all numeric columns by sex
-grouped_data.describe()
+display(grouped_data.describe())
 # Provide the mean for each numeric column by sex
 grouped_data.mean()
 ~~~
 {: .language-python}
 
-`grouped_data.mean()` **OUTPUT:**
+gives **output**
 
 ~~~
+
+ 	record_id 	month 	... 	hindfoot_length 	weight
+	count 	mean 	std 	min 	25% 	50% 	75% 	max 	count 	mean 	... 	75% 	max 	count 	mean 	std 	min 	25% 	50% 	75% 	max
+sex 																					
+F 	15690.0 	18036.412046 	10423.089000 	3.0 	8917.50 	18075.5 	27250.00 	35547.0 	15690.0 	6.583047 	... 	36.0 	64.0 	15303.0 	42.170555 	36.847958 	4.0 	20.0 	34.0 	46.0 	274.0
+M 	17348.0 	17754.835601 	10132.203323 	1.0 	8969.75 	17727.5 	26454.25 	35548.0 	17348.0 	6.392668 	... 	36.0 	58.0 	16879.0 	42.995379 	36.184981 	4.0 	20.0 	39.0 	49.0 	280.0
+
+2 rows × 56 columns
+
         record_id     month        day         year    plot_id  \
 sex
 F    18036.412046  6.583047  16.007138  1990.644997  11.440854

--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -183,11 +183,13 @@ surveys_df = pd.read_csv("data/surveys.csv")
 {: .language-python}
 
 Notice when you assign the imported DataFrame to a variable, Python does not
-produce any output on the screen. We can view the value of the `surveys_df`
-object by typing its name into the Python command prompt.
+produce any output on the screen.  The IPython package includes the display() function, which is preferable to pandas over print(). We can view the value of the `surveys_df`
+object by typing:
 
 ~~~
-surveys_df
+from IPython.display import display
+
+display(surveys_df)
 ~~~
 {: .language-python}
 
@@ -251,7 +253,7 @@ easier to fit on one window, you can see that pandas has neatly formatted the da
 our screen:
 
 ~~~
-surveys_df.head() # The head() method displays the first several lines of a file. It
+display(surveys_df.head()) # The head() method displays the first several lines of a file. It
                   # is discussed below.
 ~~~
 {: .language-python}


### PR DESCRIPTION
(a) I would suggest to introduce the use of the display() function from the IPython package, which is preferred over print() for pandas. display() give essentially the same output as typing a pandas data frame name into the Python command prompt or at the end of a code block, but it is useful for longer code blocks. 
(b) I would  suggest to explain that surveys_df.dtypes can be easily adjusted by one line of code, for instance for the 'sex' column, a categorical datatype might be preferred instead of 'object', or 'int16' instead of 'int64' for the columns 'month' or 'year'.
I hope this can be useful, let me know what you think.
