### PR TITLE
Updated the text for read_csv import option

### DIFF
--- a/_episodes/05-merging-data.md
+++ b/_episodes/05-merging-data.md
@@ -70,8 +70,10 @@ species_df
 Take note that the `read_csv` method we used can take some additional options which
 we didn't use previously. Many functions in Python have a set of options that
 can be set by the user if needed. In this case, we have told pandas to assign
-empty values in our CSV to NaN `keep_default_na=False, na_values=[""]`.
-[More about all of the read_csv options here.](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html#pandas.read_csv)
+empty values in our CSV to NaN `keep_default_na=False, na_values=[""]`. 
+We have explicitly requested to change empty values in the CSV to NaN,
+this is however also the default behaviour of `read_csv`. 
+[More about all of the `read_csv` options here and their defaults.](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html#pandas.read_csv)
 
 # Concatenating DataFrames
 


### PR DESCRIPTION
Clarified some text to point out that empty values in a CSV are by default converted to NaN. The option `keep_default_na=False, na_values=[""]` is not necessary to replace empty with NaN. Good to point the learner to the options of read_csv, though.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
