### PR TITLE
Update 00-before-we-start.md

### DIFF
--- a/_episodes/00-before-we-start.md
+++ b/_episodes/00-before-we-start.md
@@ -248,7 +248,7 @@ ask a good question.
 
 [anaconda]: https://www.anaconda.com
 [anaconda-community]: https://www.anaconda.com/community
-[dive-into-python3]: https://finderiko.com/python-book
+[dive-into-python3]: https://diveintopython3.net/
 [pandas-docs]: https://pandas.pydata.org/pandas-docs/stable/
 [pypi]: https://pypi.org/
 [python-docs]: https://www.python.org/doc


### PR DESCRIPTION
Updated the link https://finderiko.com/python-book for hyperlink 'dive-into-python3' to now go to https://diveintopython3.net/

Linking to https://finderiko.com/python-book is unhelpful for those unable to afford the book purchase cost from amazon.