### PR TITLE
Update 02-starting-with-data.md

### DIFF
--- a/_episodes/02-starting-with-data.md
+++ b/_episodes/02-starting-with-data.md
@@ -705,7 +705,7 @@ total_count.plot(kind='bar');
 [numpy]: https://www.numpy.org/
 [pandas]: https://pandas.pydata.org
 [pandas-plot]: http://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html#basic-plotting-plot
-[pd-dataframe]: https://pandas.pydata.org/pandas-docs/stable/getting_started/dsintro.html#dataframe
+[pd-dataframe]: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html
 [pptd]: https://figshare.com/articles/Portal_Project_Teaching_Database/1314459
 [python-datastructures]: https://docs.python.org/3/tutorial/datastructures.html#tuples-and-sequences
 [spreadsheet-lesson5]: http://www.datacarpentry.org/spreadsheet-ecology-lesson/05-exporting-data


### PR DESCRIPTION
The link to `[pd-dataframe]` in the references is broken; I propose updating it with the correct URL for PANDAS documentation for `DataFrame`

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
