### PR TITLE
relocate solutions for episode 01

### DIFF
--- a/episodes/01-short-introduction-to-Python.md
+++ b/episodes/01-short-introduction-to-Python.md
@@ -340,7 +340,72 @@ a_list = [1, 2, 3]
 4. What information does the built-in function `len()` provide?
   Does it provide the same information on both tuples and lists?
   Does the `help()` function confirm this?
-  
+
+::::::::::::::::::::::::::: solution
+
+1. What happens when you execute `a_list[1] = 5`?
+
+The second value in `a_list` is replaced with `5`.
+
+2. What happens when you execute `a_tuple[2] = 5`?
+
+```error
+TypeError: 'tuple' object does not support item assignment
+```
+
+As a tuple is immutable, it does not support item assignment. 
+Elements in a list can be altered individually.
+
+3. What does `type(a_tuple)` tell you about `a_tuple`?
+
+```output
+<class 'tuple'>
+```
+
+The function tells you that the variable `a_tuple` is an object of the class `tuple`.
+
+4. What information does the built-in function `len()` provide?
+  Does it provide the same information on both tuples and lists?
+  Does the `help()` function confirm this?
+
+```python
+len(a_list)
+```
+
+```output
+3
+```
+
+```python
+len(a_tuple)
+```
+
+```output
+3
+```
+
+`len()` tells us the length of an object.
+It works the same for both lists and tuples, 
+providing us with the number of entries in each case.
+
+```python
+help(len)
+```
+
+```output
+Help on built-in function len in module builtins:
+
+len(obj, /)
+    Return the number of items in a container.
+```
+
+Lists and tuples are both types of container 
+i.e. objects that can contain multiple items,
+the key difference being that lists are mutable i.e.
+they can be modified after they have been created,
+while tuples are not: their value cannot be modified, only overwritten.
+
+::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -416,8 +481,51 @@ for key in rev.keys():
   reads "two" but instead `2`.
 3. Print the value of `rev` to the screen again to see if the value has changed.
   
+::::::::::::::::::::::::::: solution
+
+1.
+
+```python
+print(rev)
+```
+
+```output
+{'first': 'one', 'second': 'two', 'third': 'three'}
+```
+
+2. and 3.
+
+```python
+rev['second'] = 2
+print(rev)
+```
+
+```output
+{'first': 'one', 'second': 2, 'third': 'three'}
+```
+
+::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::: instructor
+
+## Assigning to Dictionaries
+
+It can help to further demonstrate the freedom the user has to define
+values to keys in a dictionary, by showing another example with a value
+completely unrelated to the current contents of the dictionary, e.g.
+
+```python
+rev[2] = "apple-sauce"
+print(rev)
+```
+
+```output
+{1: 'one', 2: 'apple-sauce', 3: 'three'}
+```
+
+:::::::::::::::::::::::::::::::::::
 
 ## Functions
 

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -27,43 +27,6 @@ If learners receive an `AssertionError`, it will inform you how to help them cor
 installation. Otherwise, it will tell you that the system is good to go and ready for Data
 Carpentry!
 
-## 01-short-introduction-to-Python
-
-### Tuples Challenges
-
-- What happens when you execute `a_list[1] = 5`?
-
-- What happens when you execute `a_tuple[2] = 5`?
-  
-  As a tuple is immutable, it does not support item assignment. Elements in a list can be altered
-  individually.
-
-- What does `type(a_tuple)` tell you about `a_tuple`?
-  
-  `tuple`
-
-### Dictionaries Challenges
-
-- Changing dictionaries: 2. Reassign the value that corresponds to the key `2`.
-
-Make sure it is also clear that access to 'the value that corresponds to the key `2`' is actually
-just about the key name. Add for example `rev[10] = "ten"` to clarify it is not about the position.
-
-```python
-rev
-```
-
-```output
-{1: 'one', 2: 'two', 3: 'three'}
-```
-
-```python
-rev[2] = "apple-sauce"
-```
-
-```output
-{1: 'one', 2: 'apple-sauce', 3: 'three'}
-```
 
 ## 02-starting-with-data
 


### PR DESCRIPTION
Inspired in part by the [Instructor Notes Drive](https://carpentries.org/blog/2023/05/instructor-notes-drive-schedule/), I am going to work through the lesson episode-by-episode, relocating the exercise solutions to their relevant challenge blocks. To make the changes easier to review, I am going to create one PR per episode.

This PR takes care of the solutions for challenges in episode 2, _Short introduction to programming in Python_

This is related to #542