### PR TITLE
move instructor notes about data checkpoint inline

### DIFF
--- a/episodes/04-data-types-and-format.md
+++ b/episodes/04-data-types-and-format.md
@@ -390,6 +390,16 @@ We will use this data file later in the workshop. Check out your working directo
 sure the CSV wrote out properly, and that you can open it! If you want, try to bring it
 back into Python to make sure it imports properly.
 
+::::::::::::::::::::::: instructor
+
+## Processed Data Checkpoint
+
+If learners have trouble generating the output, or anything happens with that, the folder
+[`sample_output`](https://github.com/datacarpentry/python-ecology-lesson/tree/main/sample_output)
+in this repository contains the file `surveys_complete.csv` with the data they should generate.
+
+::::::::::::::::::::::::::::::::::
+
 ## Recap
 
 What we've learned:

--- a/episodes/07-visualization-ggplot-python.md
+++ b/episodes/07-visualization-ggplot-python.md
@@ -65,6 +65,15 @@ surveys_complete = pd.read_csv('data/surveys.csv')
 surveys_complete = surveys_complete.dropna()
 ```
 
+::::::::::::::::::::::: instructor
+
+If learners have trouble generating the output, or anything happens with that, the folder
+[`sample_output`](https://github.com/datacarpentry/python-ecology-lesson/tree/main/sample_output)
+in this repository contains the file `surveys_complete.csv` with the data they should generate.
+
+::::::::::::::::::::::::::::::::::
+
+
 ## Plotting with plotnine
 
 The `plotnine` package (cfr. other packages conform The Grammar of Graphics) supports the creation of complex plots from data in a

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -707,10 +707,6 @@ def yearly_data_csv_writer(all_data, yearcolumn="year",
 
 ## 07-visualization-ggplot-python
 
-If the students have trouble generating the output, or anything happens with that, there is a file
-called "sample output" that contains the data file they should have generated in lesson 3.
-Answers are embedded with challenges in this lesson.
-
 Note `plotnine` contains a *lot* of deprecation warnings in some versions of python/matplotlib, warnings may need to be supressed with
 
 ```python


### PR DESCRIPTION
This Instructor Note will be more helpful presented inline, next to the section that it relates to. This PR moves it there.

[Edit]: I found a similar note for episode 07, so I have updated this PR to also add an inline note there.