### PR TITLE
move .editorconfig comments one line above

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,8 +8,12 @@ trim_trailing_whitespace = true
 [*.md]
 indent_size = 2
 indent_style = space
-max_line_length = 100  # Please keep this in sync with bin/lesson_check.py!
-trim_trailing_whitespace = false  # keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>)
+
+# Please keep this in sync with bin/lesson_check.py!
+max_line_length = 100
+
+# keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>)
+trim_trailing_whitespace = false
 
 [*.r]
 max_line_length = 80


### PR DESCRIPTION
If on the same line of the value they describe, then they cause an error in some editors (e.g. nvim)