### PR TITLE
fixes a reference to an outdated error type

### DIFF
--- a/episodes/04-data-types-and-format.md
+++ b/episodes/04-data-types-and-format.md
@@ -132,7 +132,7 @@ surveys_df.dtypes
 
 which returns:
 
-```python
+```python 
 record_id            int64
 month                int64
 day                  int64
@@ -259,7 +259,7 @@ surveys_df['plot_id'].astype("float")
 2         2.0
 3         7.0
 4         3.0
-         ...
+         ... 
 35544    15.0
 35545    15.0
 35546    10.0

--- a/episodes/04-data-types-and-format.md
+++ b/episodes/04-data-types-and-format.md
@@ -68,12 +68,12 @@ numbers can not be used for mathematical operations**!
 pandas and base Python use slightly different names for data types. More on this
 is in the table below:
 
-| Pandas Type           | Native Python Type                    | Description                                                                                                                                                    | 
+| Pandas Type           | Native Python Type                    | Description                                                                                                                                                    |
 | --------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| object                | string                                | The most general dtype. Will be assigned to your column if column has mixed types (numbers and strings).                                                       | 
-| int64                 | int                                   | Numeric characters. 64 refers to the memory allocated to hold this character.                                                                                  | 
-| float64               | float                                 | Numeric characters with decimals. If a column contains numbers and NaNs (see below), pandas will default to float64, in case your missing value has a decimal. | 
-| datetime64, timedelta[ns] | N/A (but see the [datetime] module in Python's standard library)                     | Values meant to hold time data. Look into these for time series experiments.                                                                                   | 
+| object                | string                                | The most general dtype. Will be assigned to your column if column has mixed types (numbers and strings).                                                       |
+| int64                 | int                                   | Numeric characters. 64 refers to the memory allocated to hold this character.                                                                                  |
+| float64               | float                                 | Numeric characters with decimals. If a column contains numbers and NaNs (see below), pandas will default to float64, in case your missing value has a decimal. |
+| datetime64, timedelta[ns] | N/A (but see the [datetime] module in Python's standard library)                     | Values meant to hold time data. Look into these for time series experiments.                                                                                   |
 
 ## Checking the format of our data
 
@@ -132,7 +132,7 @@ surveys_df.dtypes
 
 which returns:
 
-```python 
+```python
 record_id            int64
 month                int64
 day                  int64
@@ -259,7 +259,7 @@ surveys_df['plot_id'].astype("float")
 2         2.0
 3         7.0
 4         3.0
-         ... 
+         ...
 35544    15.0
 35545    15.0
 35546    10.0
@@ -283,8 +283,8 @@ Pandas cannot convert types from float to int if the column contains NaN values.
 
 ## Missing Data Values - NaN
 
-What happened in the last challenge activity? Notice that this throws a value error:
-`ValueError: Cannot convert NA to integer`. If we look at the `weight` column in the surveys
+What happened in the last challenge activity? Notice that this raises a casting error:
+`pandas.errors.IntCastingNaNError: Cannot convert non-finite values (NA or inf) to integer` (in older versions of pandas, this may be called a `ValueError` instead). If we look at the `weight` column in the surveys
 data we notice that there are NaN (**N**ot **a** **N**umber) values. **NaN** values are undefined
 values that cannot be represented mathematically. pandas, for example, will read
 an empty cell in a CSV or Excel sheet as `NaN`. NaNs have some desirable properties: if we

--- a/episodes/04-data-types-and-format.md
+++ b/episodes/04-data-types-and-format.md
@@ -68,12 +68,12 @@ numbers can not be used for mathematical operations**!
 pandas and base Python use slightly different names for data types. More on this
 is in the table below:
 
-| Pandas Type           | Native Python Type                    | Description                                                                                                                                                    |
+| Pandas Type           | Native Python Type                    | Description                                                                                                                                                    | 
 | --------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| object                | string                                | The most general dtype. Will be assigned to your column if column has mixed types (numbers and strings).                                                       |
-| int64                 | int                                   | Numeric characters. 64 refers to the memory allocated to hold this character.                                                                                  |
-| float64               | float                                 | Numeric characters with decimals. If a column contains numbers and NaNs (see below), pandas will default to float64, in case your missing value has a decimal. |
-| datetime64, timedelta[ns] | N/A (but see the [datetime] module in Python's standard library)                     | Values meant to hold time data. Look into these for time series experiments.                                                                                   |
+| object                | string                                | The most general dtype. Will be assigned to your column if column has mixed types (numbers and strings).                                                       | 
+| int64                 | int                                   | Numeric characters. 64 refers to the memory allocated to hold this character.                                                                                  | 
+| float64               | float                                 | Numeric characters with decimals. If a column contains numbers and NaNs (see below), pandas will default to float64, in case your missing value has a decimal. | 
+| datetime64, timedelta[ns] | N/A (but see the [datetime] module in Python's standard library)                     | Values meant to hold time data. Look into these for time series experiments.                                                                                   | 
 
 ## Checking the format of our data
 


### PR DESCRIPTION
Fixes #549 by updating the reference to the error in the instructional text. To avoid confusion, the deprecated behavior (raising a `ValueError`) is also mentioned.

This is a contribution as part of my instructor checkout.

