### PR TITLE
Update join types in pandas merge function

### DIFF
--- a/episodes/05-merging-data.md
+++ b/episodes/05-merging-data.md
@@ -434,16 +434,20 @@ case, `PF`) does not occur in `species_sub`.
 
 ### Other join types
 
-The pandas `merge` function supports two other join types:
+The pandas `merge` function supports other join types:
 
 - Right (outer) join: Invoked by passing `how='right'` as an argument. Similar
   to a left join, except *all* rows from the `right` DataFrame are kept, while
   rows from the `left` DataFrame without matching join key(s) values are
   discarded.
 - Full (outer) join: Invoked by passing `how='outer'` as an argument. This join
-  type returns the all pairwise combinations of rows from both DataFrames; i.e.,
-  the result DataFrame will `NaN` where data is missing in one of the dataframes. This join type is
-  very rarely used.
+  type returns the all pairwise combinations of rows from both DataFrames; i.e., the
+  *Cartesian product* and the result DataFrame will use `NaN` where data is missing in one 
+  of the dataframes. This join type is very rarely used, but can be helpful to see all
+  the qualities of both tables, including each common and duplicate column.
+- Self-join: Joins a data frame with itself. Self-joins can be useful when you want to, for
+  instance, compare records within the same dataset based on a given criteria. A fuller discussion 
+  of how and when it might be useful to do so can be found in [Self-Join and Cross Join in Pandas DataFrame](https://blog.devgenius.io/self-join-and-cross-join-in-pandas-dataframe-b30bfbc0e52a)
 
 ## Final Challenges
 


### PR DESCRIPTION
Closes #583

Expanded description of cross join with suggestions and added self-joins with a resource for users to explore that further on their own time if they need that approach.  Joins is already a relatively heavy subject for learners to grapple with so opted not to have full pedagogical sections covering these additional join types in detail.



