### PR TITLE
Add consistency to comparison operators list

### DIFF
--- a/episodes/03-index-slice-subset.md
+++ b/episodes/03-index-slice-subset.md
@@ -508,9 +508,10 @@ Experiment with selecting various subsets of the "surveys" data.
 
 - Equals: `==`
 - Not equals: `!=`
-- Greater than, less than: `>` or `<`
-- Greater than or equal to `>=`
-- Less than or equal to `<=`
+- Greater than: `>`
+- Less than: `<`
+- Greater than or equal to: `>=`
+- Less than or equal to: `<=`
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
In the interest of better readability, this PR adds consistency to the comparison operators list by:
* Putting `<` and `>` on their own lines just as `<=` and `>=` are on their own lines
* Adding colon at each definition (only some terms had this colon)