### PR TITLE
Update 07-visualization-ggplot-python.md

### DIFF
--- a/episodes/07-visualization-ggplot-python.md
+++ b/episodes/07-visualization-ggplot-python.md
@@ -631,12 +631,12 @@ my_plot.save("scatterplot.png", width=10, height=10, dpi=300)
 
 
 
-[plotnine]: https://plotnine.readthedocs.io/en/stable
+[plotnine]: https://github.com/has2k1/plotnine?tab=readme-ov-file
 [ggplot2]: https://ggplot2.tidyverse.org
 [grammar-of-graphics]: https://link.springer.com/book/10.1007%2F0-387-28695-0
-[setup-plotnine]: https://datacarpentry.org/python-ecology-lesson/setup.html#required-python-packages
-[plotnine-api]: https://plotnine.readthedocs.io/en/stable/api.html#color-and-fill-scales
-[ggplot2-cheat-sheet]: https://www.rstudio.com/wp-content/uploads/2015/08/ggplot2-cheatsheet.pdf
+[setup-plotnine]: https://datacarpentry.org/python-ecology-lesson/#required-python-packages
+[plotnine-api]: https://plotnine.org/reference/
+[ggplot2-cheat-sheet]: https://rstudio.github.io/cheatsheets/html/data-visualization.html
 
 
 :::::::::::::::::::::::::::::::::::::::: keypoints


### PR DESCRIPTION
Closes #599

Correcte API link, setup-plotnine, and ggplot2-cheat-sheet.

Also fixed documentation link by pointing it to read me on github, which is the best option I could find.  That read me has several examples and  directs users to plotnine homepage which has less guidance than the read me and then punts to gg-plot documentation for additional coverage.   Is there a better solution for that particular link?
