### PR TITLE
Fix typo in 'Slicing Subsets of Rows and Columns in Python.' Change sentence grammar slightly.

### DIFF
--- a/episodes/03-index-slice-subset.md
+++ b/episodes/03-index-slice-subset.md
@@ -313,8 +313,8 @@ surveys_df = pd.read_csv("data/surveys.csv")
 We can select specific ranges of our data in both the row and column directions
 using either label or integer-based indexing.
 
-- `iloc` is primarily an *integer* based indexing counting from 0. That is, your
-  specify rows and columns giving a number. Thus, the first row is row 0,
+- `iloc` is primarily an *integer* based indexing counting from 0. That is, you
+  specify rows and columns using a number. Thus, the first row is row 0,
   the second column is column 1, etc.
 
 - `loc` is primarily a *label* based indexing where you can refer to rows and


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

The following changes applied to the section "Slicing Subsets of Rows and Columns in Python" in Episode 3.

- Fixed the typo "That is, YOUR specify rows and columns giving a number." 
- Updated "giving" to "using" in above phrase - i.e. "That is, you specify rows and columns using a number."

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
