### PR TITLE
per #529

### DIFF
--- a/episodes/00-before-we-start.md
+++ b/episodes/00-before-we-start.md
@@ -116,6 +116,8 @@ the backbone of your project's directory. For this workshop, we will need a `dat
 our raw data, and we will later create a `data_output/` folder when we learn how to export data as
 CSV files.
 
+Let's take a moment to locate, create, and populate those before proceeding.
+
 ## What is Programming and Coding?
 
 Programming is the process of writing *"programs"* that a computer can execute and produce some


### PR DESCRIPTION
per #529 

I am starting an edit to anchor the discussion.  I spent an hour trying to find where I was, where python was, where the notebook was, and extracting the zip.  This is not at all explicit nor intuitive.  Is this an instructor note (explaining students or workshop may have skipped Shell and Git lessons)?  Or additional steps to encode as code boxes?

Today One organizer used:
The instructions as is didn’t activate everything correctly for the mac users, so I followed these instructions through step six https://carpentries.github.io/workshop-template/install_instructions/#python
Then I did source /Users/insertusername/miniforge3/bin/activate
conda env create -f ~/Downloads/carpentries_environment.yml
conda activate carpentries
jupyter notebook"
